### PR TITLE
updates for ls command

### DIFF
--- a/src/controllers/dir.js
+++ b/src/controllers/dir.js
@@ -11,7 +11,9 @@ router.get(/(.*)/, async (req, res) => {
     const directoryPath = req.params[0] || '/';
     const resp = await caskFs.ls({
       directory: directoryPath,
-      corkTraceId: req.corkTraceId
+      offset: req.query.offset,
+      limit: req.query.limit,
+      query: req.query.query
     });
     res.status(200).json(resp);
   } catch (e) {

--- a/src/lib/directory.js
+++ b/src/lib/directory.js
@@ -14,13 +14,14 @@ class Directory {
    * @method get
    * @description Get a directory by its path.  If no path is provided, the root directory is returned.
    *
-   * @param {String} directory directory path
-   * @param {Object} opts
-   * @param {Object} opts.dbClient Required. database client instance
+   * @param {Object|CaskFSContext} context query options
+   * @param {String} context.directory directory path
+   * @param {Object} context.dbClient Required. database client instance
    * @returns {Promise<Directory>} Directory instance
    */
-  async get(directory, opts={}) {
-    return opts.dbClient.getDirectory(directory || '/');
+  async get(context={}) {
+    let {dbClient, directory} = context.data
+    return dbClient.getDirectory(directory || '/');
   }
 
   /**
@@ -30,11 +31,14 @@ class Directory {
    * @param {String} directory directory path
    * @param {Object} opts
    * @param {Object} opts.dbClient Required. database client instance
+   * @param {Number} opts.limit number of child directories to return, defaults to 100
+   * @param {Number} opts.offset offset for return set
    *
    * @returns {Promise<Array>} array of child directory objects
    */
-  async getChildren(directory, opts={}) {
-    return opts.dbClient.getChildDirectories(directory, opts);
+  async getChildren(context={}) {
+    let {dbClient, directory, limit, offset, requestor, query} = context.data;
+    return dbClient.getChildDirectories(directory, {limit, offset, requestor, query});
   }
 
   /**


### PR DESCRIPTION
@spelkey-ucd 

This PR does a couple things of interest for the UI:

- There is (finally) proper offset and limit.  defaults to 0 and 100 respectively.
- There is a new `query` parameter that can be used to limit results by filename or directory name.  This works on partial match... ie typeahead. 
- Total results (directories + files) is returned in the API

These parameters have been integrated into the api controller as url query parameters.  Can you

 - Integrate them into the dir view/pagination widget?  You can just request what you need to display now.
 - I want to add a type ahead text box after the bread crumbs if there is paging.  This will let users quickly filter to a file or folder if they know what they want (AE has 4k user names in a folder, for example).  Set focus on this box if user hits `tab`.  ie make sure priority tab index.

Other note.  The offset and limit are interesting.  They are a combined offset and limit from the both `directory` and `file` tables.  The api ... should ... handle the offset correctly when you have paged past the folders and are now show files.  There is a helper `file.offset/limit` in the response to show you what offset was used on the file table based on the results from the directory table.